### PR TITLE
Refractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "openid-client": "^5.4.0",
     "otplib": "^12.0.1",
     "passport": "^0.6.0",
+    "passport-anonymous": "^1.0.1",
     "passport-github2": "^0.1.12",
     "passport-google-oauth": "^2.0.0",
     "passport-jwt": "^4.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,13 +3,10 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
-import { ClsModule } from 'nestjs-cls';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
-import { IClsStore } from './auth/interfaces/cls-store.interface';
 import { CommonModule } from './common/common.module';
-import { LocalFileService } from './common/local-file.service';
 import { UserModule } from './user/user.module';
 
 @Module({
@@ -39,35 +36,7 @@ import { UserModule } from './user/user.module';
         };
       },
     }),
-    ClsModule.forRootAsync({
-      useFactory: async (
-        redisService: RedisService,
-        localFileService: LocalFileService,
-        configService: ConfigService,
-      ) => {
-        return {
-          middleware: {
-            mount: true,
-            setup: async (cls) => {
-              const data = await localFileService.dataFromFile<IClsStore>(
-                `${process.cwd()}/cls.json`,
-              );
-              await redisService
-                .getClient()
-                .set(
-                  configService.get('REDIS_AUTH_CONFIG_KEY') || 'AUTH_CONFIG',
-                  JSON.stringify(data),
-                );
-              // console.log(data);
-              for (const key in data) {
-                cls.set(key, data[key]);
-              }
-            },
-          },
-        };
-      },
-      inject: [RedisService, LocalFileService, ConfigService],
-    }),
+
     UserModule,
   ],
   controllers: [AppController],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -12,8 +12,6 @@ import { AuthConfigController } from './controllers/auto-config.controller';
 import { GithubGuard } from './guards/github.guard';
 import { GoogleGuard } from './guards/google.guard';
 import { JwtGuard } from './guards/jwt.guard';
-import { GithubStrategy } from './strategies/github.strategy';
-import { GoogleStrategy } from './strategies/google.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { TwoFactorController } from './controllers/two-factor.controller';
 import { TwoFactorAuthenticationService } from './services/otp.service';
@@ -21,6 +19,11 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { TwoFactorGuard } from './guards/two-factor.guard';
 import { TwoFactorAuthStrategy } from './strategies/2fa.strategy';
+import { RedisService } from '@liaoliaots/nestjs-redis';
+import { LocalFileService } from 'src/common/local-file.service';
+import { clsFactory } from './helpers/cls-store.factory';
+import { githubStrategyProxyFactory } from './helpers/github-strategy.factory';
+import { googleStrategyProxyFactory } from './helpers/google-strategy.factory';
 
 @Module({
   imports: [
@@ -32,20 +35,20 @@ import { TwoFactorAuthStrategy } from './strategies/2fa.strategy';
     }),
     HttpModule.register({}),
     RequestScopeModule,
+    ClsModule.forRootAsync({
+      useFactory: clsFactory,
+      inject: [RedisService, LocalFileService, ConfigService],
+    }),
     ClsModule.forFeatureAsync({
       provide: 'GITHUB_STRATEGY',
       imports: [UserModule],
-      useFactory: (clsService: ClsService, userService: UserService) => {
-        return new GithubStrategy(clsService, userService);
-      },
+      useFactory: githubStrategyProxyFactory,
       inject: [ClsService, UserService],
     }),
     ClsModule.forFeatureAsync({
       provide: 'GOOGLE_STRATEGY',
       imports: [UserModule],
-      useFactory: (clsService: ClsService, userService: UserService) => {
-        return new GoogleStrategy(clsService, userService);
-      },
+      useFactory: googleStrategyProxyFactory,
       inject: [ClsService, UserService],
     }),
   ],

--- a/src/auth/controllers/auto-config.controller.ts
+++ b/src/auth/controllers/auto-config.controller.ts
@@ -6,6 +6,7 @@ import { IClsStore } from '../interfaces/cls-store.interface';
 import { Redis } from 'ioredis';
 import { ConfigService } from '@nestjs/config';
 import { ZodValidationPipe } from '@anatine/zod-nestjs';
+import { ClsService } from 'nestjs-cls';
 
 @Controller({
   path: 'auth-config',
@@ -16,6 +17,7 @@ export class AuthConfigController {
     private readonly localFileService: LocalFileService,
     @InjectRedis() private readonly redis: Redis,
     private configService: ConfigService,
+    private cls: ClsService,
   ) {}
 
   get redisAuthConfigKey() {
@@ -43,9 +45,7 @@ export class AuthConfigController {
 
   @Post()
   async updateConfigDetails(@Body() dto: UpdateAuthConfigDto) {
-    const currentConfig = await this.localFileService.dataFromFile<IClsStore>(
-      `${process.cwd()}/cls.json`,
-    );
+    const currentConfig = this.cls.get<IClsStore>();
     await this.localFileService.dataToFile(`${process.cwd()}/cls.json`, {
       ...currentConfig,
       ...dto,

--- a/src/auth/controllers/two-factor.controller.ts
+++ b/src/auth/controllers/two-factor.controller.ts
@@ -48,7 +48,6 @@ export class TwoFactorController {
   @Get('qr')
   @UseGuards(JwtGuard)
   async getQr(@Req() req: Request, @Res() res: Response) {
-    console.log(req.user);
     const { otpAuthUrl } = await this.tfaService.getSecret(
       (req.user as IJWTClaims).id,
     );
@@ -58,7 +57,6 @@ export class TwoFactorController {
   @Get('generate')
   @UseGuards(JwtGuard)
   async setup2fa(@Res() res: Response, @Req() req: Request) {
-    console.log(req.user);
     const { otpAuthUrl } =
       await this.tfaService.generateTwoFactorAuthenticationSecret(
         (req.user as IJWTClaims).id,
@@ -91,7 +89,6 @@ export class TwoFactorController {
         secret: this.configService.get('JWT_SECRET'),
       },
     );
-    console.log(accessTokenCookie);
     res.cookie('jwt', accessTokenCookie);
     res.send({
       user: req.user,
@@ -106,7 +103,6 @@ export class TwoFactorController {
     @Body() body: Verify2FATokenDto,
     @Res() res: Response,
   ) {
-    console.log(req.user);
     const isValid = await this.tfaService.verify(
       (req.user as IJWTClaims).id,
       body.token,

--- a/src/auth/helpers/cls-store.factory.ts
+++ b/src/auth/helpers/cls-store.factory.ts
@@ -1,0 +1,64 @@
+import { RedisService } from '@liaoliaots/nestjs-redis';
+import { LoggerService } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ClsModuleFactoryOptions } from 'nestjs-cls';
+import { LocalFileService } from 'src/common/local-file.service';
+import { IClsStore } from '../interfaces/cls-store.interface';
+import { clsZod } from './cls-store.zod';
+
+export const clsFactory: (
+  ...args: any[]
+) => ClsModuleFactoryOptions | Promise<ClsModuleFactoryOptions> = async (
+  redisService: RedisService,
+  localFileService: LocalFileService,
+  configService: ConfigService,
+  logger: LoggerService,
+) => {
+  return {
+    middleware: {
+      mount: true,
+      setup: async (cls) => {
+        const configString = await redisService
+          .getClient()
+          .get(configService.get('REDIS_AUTH_CONFIG_KEY') || 'AUTH_CONFIG');
+        if (!configString) {
+          logger.log(
+            'Fail to retrieve data from redis, procceeding with local config files',
+          );
+          const data = await localFileService.dataFromFile<IClsStore>(
+            `${process.cwd()}/cls.json`,
+          );
+          let zodParsedData;
+          try {
+            zodParsedData = clsZod.parse(data);
+            console.log(zodParsedData);
+          } catch (e) {
+            logger.error(e);
+          }
+          await redisService
+            .getClient()
+            .set(
+              configService.get('REDIS_AUTH_CONFIG_KEY') || 'AUTH_CONFIG',
+              JSON.stringify(zodParsedData),
+            );
+          for (const key in zodParsedData) {
+            cls.set(key, data[key]);
+          }
+          return;
+        } else {
+          const config = JSON.parse(configString);
+          let parsedConfig;
+          try {
+            parsedConfig = clsZod.parse(config);
+            console.log(parsedConfig);
+          } catch (e) {
+            logger.error(e);
+          }
+          for (const key in parsedConfig) {
+            cls.set(key, config[key]);
+          }
+        }
+      },
+    },
+  };
+};

--- a/src/auth/helpers/cls-store.zod.ts
+++ b/src/auth/helpers/cls-store.zod.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const clsZod = z.object({
+  willAuthenticate: z.boolean().default(false),
+  mfaEnforce: z.boolean().default(false),
+  githubProviderOptions: z.object({
+    active: z.boolean().default(false),
+    clientID: z.string().default(''),
+    clientSecret: z.string().default(''),
+    callbackURL: z.string().default(''),
+    scope: z.string().default(''),
+  }),
+  googleProviderOptions: z.object({
+    active: z.boolean().default(false),
+    clientID: z.string().default(''),
+    clientSecret: z.string().default(''),
+    callbackURL: z.string().default(''),
+    scope: z.string().default(''),
+  }),
+});

--- a/src/auth/helpers/github-strategy.factory.ts
+++ b/src/auth/helpers/github-strategy.factory.ts
@@ -1,0 +1,15 @@
+import { ClsService } from 'nestjs-cls';
+import { UserService } from 'src/user/user.service';
+import { createAnonymousStrategy } from '../strategies/anonymous.strategy';
+import { GithubStrategy } from '../strategies/github.strategy';
+
+export const githubStrategyProxyFactory = (
+  clsService: ClsService,
+  userService: UserService,
+) => {
+  const active = clsService.get('githubProviderOptions').active;
+  if (!active) {
+    return createAnonymousStrategy('github-oauth');
+  }
+  return new GithubStrategy(clsService, userService);
+};

--- a/src/auth/helpers/google-strategy.factory.ts
+++ b/src/auth/helpers/google-strategy.factory.ts
@@ -1,0 +1,16 @@
+import { ClsService } from 'nestjs-cls';
+import { UserService } from 'src/user/user.service';
+import { createAnonymousStrategy } from '../strategies/anonymous.strategy';
+import { GoogleStrategy } from '../strategies/google.strategy';
+
+export const googleStrategyProxyFactory = (
+  clsService: ClsService,
+  userService: UserService,
+) => {
+  const active = clsService.get('googleProviderOptions').active;
+
+  if (!active) {
+    return createAnonymousStrategy('google-oauth');
+  }
+  return new GoogleStrategy(clsService, userService);
+};

--- a/src/auth/interfaces/cls-store.interface.ts
+++ b/src/auth/interfaces/cls-store.interface.ts
@@ -6,7 +6,7 @@ export interface IClsStore {
 }
 
 export interface IProviderOptions {
-  active: string;
+  active: boolean;
   clientID: string;
   clientSecret: string;
   callbackURL: string;

--- a/src/auth/strategies/anonymous.strategy.ts
+++ b/src/auth/strategies/anonymous.strategy.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-anonymous';
+
+// mixin
+export function createAnonymousStrategy(name: string) {
+  @Injectable()
+  class AnonymousStrategy extends PassportStrategy(Strategy, name) {}
+  return new AnonymousStrategy();
+}

--- a/src/auth/strategies/github.strategy.ts
+++ b/src/auth/strategies/github.strategy.ts
@@ -17,7 +17,6 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github-oauth') {
       profile.id,
       profile.provider,
     );
-    // console.log(profile);
     if (currentUser) {
       return {
         user: currentUser,

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -20,7 +20,6 @@ export class GoogleStrategy extends PassportStrategy(
       profile.id,
       profile.provider,
     );
-    // console.log(currentUser);
     if (currentUser) {
       return {
         user: currentUser,
@@ -40,7 +39,6 @@ export class GoogleStrategy extends PassportStrategy(
         name: 'google',
         token: accessToken,
       });
-      // console.log(newUser);
       return {
         user: newUser,
         accessToken,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -29,7 +29,6 @@ export class UserService {
 
   async createUser(userDto: CreateUserDto) {
     const newUser = new this.userModel(userDto);
-    console.log(newUser);
     return await newUser.save();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4256,6 +4256,13 @@ parseurl@~1.3.3:
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+passport-anonymous@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/passport-anonymous/-/passport-anonymous-1.0.1.tgz#241e37274ec44dfb7f6cad234b41c438386bc117"
+  integrity sha512-Mk2dls97nLTzHpsWCYQ54IVGucWaiWSHHr3+IhWYAebg4dRgRQIfyoeYrixoxB2z2z4+EM7p9yjC+a3yMB5z5A==
+  dependencies:
+    passport-strategy "1.x.x"
+
 passport-github2@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/passport-github2/-/passport-github2-0.1.12.tgz#a72ebff4fa52a35bc2c71122dcf470d1116f772c"


### PR DESCRIPTION
- Update config storage piority: redis > local file
- Seperated some logic into their own functions/files
- Added a zod parse fallback for config read from redis/files
- Added a anonymouse strategy for when github/google authentication is disabled (for safety measure mostly)
- Move some module setup into auth module instead of app module